### PR TITLE
Requires Go 1.20+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
 
       matrix:
         golang:
-          # TODO: Enable after repo is published
-          # - "1.22"
+          - "1.20"
+          - "1.21"
+          - "1.22"
           - "1.23"
         ruby:
           - "3.3"

--- a/.github/workflows/ruby_h_to_go.yml
+++ b/.github/workflows/ruby_h_to_go.yml
@@ -30,8 +30,9 @@ jobs:
 
       matrix:
         golang:
-          # TODO: Enable after repo is published
-          # - "1.22"
+          - "1.20"
+          - "1.21"
+          - "1.22"
           - "1.23"
         ruby:
           - "3.3"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ruby-go-gem/go-gem-wrapper
 
-go 1.23
+go 1.20
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
[`unsafe.String`](https://github.com/ruby-go-gem/go-gem-wrapper/blob/85e879c54676b05961a4f88b0690432f6616c446/ruby/wrapper.go#L57) requires Go 1.20+
