### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,11 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: /tmp/changelog.md
+
+      - name: Slack Notification (not success)
+        uses: act10ns/slack@v2
+        if: "! success()"
+        continue-on-error: true
+        with:
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Generate changelog
         run: |
           bundle exec rake changelog[,${TAG_NAME}] > /tmp/changelog.md
+          cat /tmp/changelog.md
         env:
           TAG_NAME: ${{ github.ref_name }}
 


### PR DESCRIPTION
ref. https://github.com/ruby-go-gem/go-gem-wrapper/actions/runs/11642268067/job/32421673488

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```