### PR TITLE
Fix cannot load such file -- ruby_h_to_go/cli (LoadError) in `rake ruby_h_to_go`

### DIFF
--- a/_tools/ruby_h_to_go/lib/ruby_h_to_go.rb
+++ b/_tools/ruby_h_to_go/lib/ruby_h_to_go.rb
@@ -3,15 +3,17 @@
 require "forwardable"
 require "ruby_header_parser"
 
+require_relative "ruby_h_to_go/type_helper"
+
+require_relative "ruby_h_to_go/argument_definition"
+require_relative "ruby_h_to_go/cli"
+require_relative "ruby_h_to_go/go_util"
+require_relative "ruby_h_to_go/enum_definition"
+require_relative "ruby_h_to_go/function_definition"
+require_relative "ruby_h_to_go/struct_definition"
+require_relative "ruby_h_to_go/type_definition"
+require_relative "ruby_h_to_go/typeref_definition"
+
 # Generate Go binding from ruby.h
 module RubyHToGo
-  autoload :ArgumentDefinition, "ruby_h_to_go/argument_definition"
-  autoload :Cli,                "ruby_h_to_go/cli"
-  autoload :GoUtil,             "ruby_h_to_go/go_util"
-  autoload :EnumDefinition,     "ruby_h_to_go/enum_definition"
-  autoload :FunctionDefinition, "ruby_h_to_go/function_definition"
-  autoload :StructDefinition,   "ruby_h_to_go/struct_definition"
-  autoload :TypeDefinition,     "ruby_h_to_go/type_definition"
-  autoload :TypeHelper,         "ruby_h_to_go/type_helper"
-  autoload :TyperefDefinition,  "ruby_h_to_go/typeref_definition"
 end


### PR DESCRIPTION

```
$ be rake ruby_h_to_go
./_tools/ruby_h_to_go/exe/ruby_h_to_go
/Users/sue445/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': cannot load such file -- ruby_h_to_go/cli (LoadError)
        from /Users/sue445/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from ./_tools/ruby_h_to_go/exe/ruby_h_to_go:52:in `<main>'
rake aborted!
Command failed with status (1): [./_tools/ruby_h_to_go/exe/ruby_h_to_go]
/Users/sue445/workspace/github.com/ruby-go-gem/go-gem-wrapper/_tasks/ruby_h_to_go.rake:14:in `block in <top (required)>'
/Users/sue445/workspace/github.com/ruby-go-gem/go-gem-wrapper/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/sue445/workspace/github.com/ruby-go-gem/go-gem-wrapper/vendor/bundle/ruby/3.3.0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in `load'

```