### PR TITLE
Restore `ruby_minor_version_build_tag` test

### DIFF
--- a/_gem/spec/go_gem/util_spec.rb
+++ b/_gem/spec/go_gem/util_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe GoGem::Util do
+  describe ".ruby_minor_version_build_tag" do
+    subject { GoGem::Util.ruby_minor_version_build_tag(ruby_version) }
+
+    let(:ruby_version) { "3.4.1" }
+
+    it { should eq "ruby_3_4" }
+  end
+end


### PR DESCRIPTION
I had deleted it in 7b67323060d1f408c7de506c97b6fa16a618d102 by mistake...