### PR TITLE
Treat `RSTRING_END` return value as a `char*` instead of `string`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   gem "rake"
   gem "rubocop", require: false
   gem "rubocop_auto_corrector", require: false
-  gem "ruby_header_parser", ">= 0.4.1"
+  gem "ruby_header_parser", ">= 0.4.2"
   gem "yard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     rubocop_auto_corrector (0.5.0)
       rubocop (>= 1.30.0)
     ruby-progressbar (1.13.0)
-    ruby_header_parser (0.4.1)
+    ruby_header_parser (0.4.2)
     securerandom (0.4.1)
     serverspec (2.42.3)
       multi_json
@@ -173,7 +173,7 @@ DEPENDENCIES
   rspec-temp_dir
   rubocop
   rubocop_auto_corrector
-  ruby_header_parser (>= 0.4.1)
+  ruby_header_parser (>= 0.4.2)
   serverspec
   steep
   test-unit

--- a/_tools/ruby_h_to_go/exe/ruby_h_to_go
+++ b/_tools/ruby_h_to_go/exe/ruby_h_to_go
@@ -49,4 +49,6 @@ include_paths ||= DEFAULT_INCLUDE_PATHS
 dist_dir ||= DEFAULT_DIST_DIR
 dist_preprocessed_header_file ||= DEFAULT_DIST_PREPROCESSED_HEADER_FILE
 
+FileUtils.rm_f(dist_preprocessed_header_file)
+
 RubyHToGo::Cli.new(header_file:, include_paths:, dist_dir:, dist_preprocessed_header_file:).perform

--- a/_tools/ruby_h_to_go/spec/ruby_h_to_go/function_definition_spec.rb
+++ b/_tools/ruby_h_to_go/spec/ruby_h_to_go/function_definition_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe RubyHToGo::FunctionDefinition do
         RubyHeaderParser::FunctionDefinition.new(
           name:       "RSTRING_END",
           definition: "RSTRING_END(VALUE str)",
-          typeref:    typeref(type: "char", pointer: :ref),
+          typeref:    typeref(type: "char", pointer: :raw),
           args:       [
             argument(type: "VALUE", name: "str"),
           ],
@@ -318,8 +318,8 @@ RSpec.describe RubyHToGo::FunctionDefinition do
           // Original definition is following
           //
           //	RSTRING_END(VALUE str)
-          func RSTRING_END(str VALUE) string {
-          return char2String(C.RSTRING_END(C.VALUE(str)))
+          func RSTRING_END(str VALUE) *Char {
+          return (*Char)(C.RSTRING_END(C.VALUE(str)))
           }
 
         GO

--- a/ruby/function_ruby_3_3_generated.go
+++ b/ruby/function_ruby_3_3_generated.go
@@ -401,8 +401,8 @@ func RB_UNDEF_P(obj VALUE) Bool {
 // Original definition is following
 //
 //	RSTRING_END(VALUE str)
-func RSTRING_END(str VALUE) string {
-	return char2String(C.RSTRING_END(C.VALUE(str)))
+func RSTRING_END(str VALUE) *Char {
+	return (*Char)(C.RSTRING_END(C.VALUE(str)))
 }
 
 // RSTRING_LEN calls `RSTRING_LEN` in C

--- a/ruby/function_ruby_3_4_generated.go
+++ b/ruby/function_ruby_3_4_generated.go
@@ -399,8 +399,8 @@ func RB_UNDEF_P(obj VALUE) Bool {
 // Original definition is following
 //
 //	RSTRING_END(VALUE str)
-func RSTRING_END(str VALUE) string {
-	return char2String(C.RSTRING_END(C.VALUE(str)))
+func RSTRING_END(str VALUE) *Char {
+	return (*Char)(C.RSTRING_END(C.VALUE(str)))
 }
 
 // RSTRING_LEN calls `RSTRING_LEN` in C
@@ -8378,9 +8378,9 @@ func RbSym2Id(obj VALUE) ID {
 //
 // Original definition is following
 //
-//	VALUE rb_sym2str(VALUE id)
-func RbSym2Str(id VALUE) VALUE {
-	return VALUE(C.rb_sym2str(C.VALUE(id)))
+//	VALUE rb_sym2str(VALUE symbol)
+func RbSym2Str(symbol VALUE) VALUE {
+	return VALUE(C.rb_sym2str(C.VALUE(symbol)))
 }
 
 // RbSymAllSymbols calls `rb_sym_all_symbols` in C


### PR DESCRIPTION
ref. https://github.com/ruby-go-gem/ruby_header_parser/pull/33