### PR TITLE
Tweak task desc in `go_gem/rake_task`

### DIFF
--- a/_gem/lib/go_gem/rake_task.rb
+++ b/_gem/lib/go_gem/rake_task.rb
@@ -134,7 +134,7 @@ module GoGem
     private
 
     def define_go_test_task
-      desc "Run #{go_bin_path} test"
+      desc "Run `#{go_bin_path} test`"
       task(:test) do
         within_target_dir do
           sh RakeTask.build_env_vars, "#{go_bin_path} test #{go_test_args} ./..."
@@ -143,7 +143,7 @@ module GoGem
     end
 
     def define_go_testrace_task
-      desc "Run #{go_bin_path} test -race"
+      desc "Run `#{go_bin_path} test -race`"
       task(:testrace) do
         within_target_dir do
           sh RakeTask.build_env_vars, "#{go_bin_path} test #{go_test_args} -race ./..."
@@ -152,7 +152,7 @@ module GoGem
     end
 
     def define_go_fmt_task
-      desc "Run #{go_bin_path} fmt"
+      desc "Run `#{go_bin_path} fmt`"
       task(:fmt) do
         within_target_dir do
           sh "#{go_bin_path} fmt ./..."
@@ -182,7 +182,7 @@ module GoGem
     end
 
     def define_go_mod_tidy_task
-      desc "Run #{go_bin_path} mod tidy"
+      desc "Run `#{go_bin_path} mod tidy`"
       task(:mod_tidy) do
         within_target_dir do
           sh "#{go_bin_path} mod tidy"

--- a/_tasks/go.rake
+++ b/_tasks/go.rake
@@ -6,7 +6,7 @@ go_task = GoGem::RakeTask.new("") do |t|
 end
 
 namespace :go do
-  desc "Run golangci-lint"
+  desc "Run `golangci-lint`"
   task :lint do
     go_task.within_target_dir do
       sh "which golangci-lint" do |ok, _|


### PR DESCRIPTION
# Before
```sh
$ be rake -T | grep "rake go:"
rake go:build_all                  # Run all build tasks in go
rake go:build_envs[env_name]       # Print build envs for `go build`
rake go:build_tag                  # Print build tag
rake go:fmt                        # Run go fmt
rake go:lint                       # Run golangci-lint
rake go:mod_tidy                   # Run go mod tidy
rake go:test                       # Run go test
rake go:testrace                   # Run go test -race
```

# After
```sh
$ be rake -T | grep "rake go:"
rake go:build_all                  # Run all build tasks in go
rake go:build_envs[env_name]       # Print build envs for `go build`
rake go:build_tag                  # Print build tag
rake go:fmt                        # Run `go fmt`
rake go:lint                       # Run `golangci-lint`
rake go:mod_tidy                   # Run `go mod tidy`
rake go:test                       # Run `go test`
rake go:testrace                   # Run `go test -race`
```