### PR TITLE
Revert "Release gem from GitHub Actions "

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,65 +1,21 @@
-name: Publish new version
+name: Create releases
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  actions: read
+  pull-requests: read
 
 jobs:
-  publish-gem:
-    name: Publish gem to rubygems.org
-
-    if: github.repository == 'ruby-go-gem/go-gem-wrapper'
+  publish:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: _gem/
-
-    environment:
-      name: rubygems.org
-      url: https://rubygems.org/gems/go_gem
-
-    permissions:
-      contents: write
-      id-token: write
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
-        with:
-          bundler-cache: true
-          ruby-version: ruby
-
-      - name: Publish to RubyGems
-        uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
-
-  create-release:
-    needs:
-      - publish-gem
-
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      actions: read
-      pull-requests: read
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
         with:
@@ -68,13 +24,13 @@ jobs:
 
       - name: Generate changelog
         run: |
-          version=$(bundle exec ruby -e 'puts GoGem::VERSION')
-          bundle exec rake changelog[,v${version}] > /tmp/changelog.md
+          bundle exec rake changelog[,${TAG_NAME}] > /tmp/changelog.md
           cat /tmp/changelog.md
         env:
+          TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create release
+      - name: Release
         uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           body_path: /tmp/changelog.md

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ open http://localhost:6060/pkg/github.com/ruby-go-gem/go-gem-wrapper/ruby/
 1. Run `bundle exec rake changelog`
 2. Add release note to [CHANGELOG.md](CHANGELOG.md)
 3. Update [_gem/lib/go_gem/version.rb](_gem/lib/go_gem/version.rb)
-4. Run https://github.com/ruby-go-gem/go-gem-wrapper/actions/workflows/release.yml
+4. Run `bundle exec rake release`
 
 ## Original idea
 [Ruby meets Go - RubyKaigi 2015](https://rubykaigi.org/2015/presentations/mmasaki/)

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,13 @@ end
 
 Dir["#{__dir__}/_tasks/*.rake"].each { |f| load f }
 
+desc "Release package"
+task :release do
+  Dir.chdir(File.join(__dir__, "_gem")) do
+    sh "rake release"
+  end
+end
+
 desc "Generate changelog entry"
 task :changelog, [:before, :after] do |_, params|
   args = []


### PR DESCRIPTION
Reverts ruby-go-gem/go-gem-wrapper#361

Same error as #356 😭 

```
Run bundle exec rake release
bundler: failed to load command: rake (/home/runner/work/go-gem-wrapper/go-gem-wrapper/vendor/bundle/ruby/3.4.0/bin/rake)
/opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/runtime.rb:321:in 'Bundler::Runtime#check_for_activated_spec!': You have already activated zlib 3.2.1, but your Gemfile requires zlib 3.2.2. Since zlib is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports zlib as a default gem. (Gem::LoadError)
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/runtime.rb:25:in 'block in Bundler::Runtime#setup'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/spec_set.rb:224:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/spec_set.rb:224:in 'Bundler::SpecSet#each'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/runtime.rb:24:in 'Enumerable#map'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/runtime.rb:24:in 'Bundler::Runtime#setup'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler.rb:165:in 'Bundler.setup'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/setup.rb:32:in 'block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/ui/shell.rb:177:in 'Bundler::UI::Shell#with_level'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/ui/shell.rb:122:in 'Bundler::UI::Shell#silence'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/setup.rb:32:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:59:in 'Kernel#require_relative'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:24:in 'Bundler::CLI::Exec#run'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:494:in 'Bundler::CLI#exec'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/exe/bundle:28:in 'block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/exe/bundle:20:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/bin/bundle:25:in 'Kernel#load'
	from /opt/hostedtoolcache/Ruby/3.4.3/x64/bin/bundle:25:in '<main>'
Error: Process completed with exit code 1.
```

https://github.com/ruby-go-gem/go-gem-wrapper/actions/runs/19987286576/job/57323060685