### PR TITLE
Add _gem/README.md to yard

### DIFF
--- a/.yard/go_gem_README.md
+++ b/.yard/go_gem_README.md
@@ -1,0 +1,1 @@
+{include:file:_gem/README.md}

--- a/.yardopts
+++ b/.yardopts
@@ -7,3 +7,4 @@ _gem/**/*.rb
 -
 CHANGELOG.md
 LICENSE
+.yard/go_gem_README.md


### PR DESCRIPTION
# Example 1 (this patch)
```
# .yardopts
.yard/go_gem_README.md
```

<img width="185" height="196" alt="image" src="https://github.com/user-attachments/assets/982f7e78-aec7-4be1-a228-05fef5765f23" />

# Example 2 (Ithis works, but this is hard to see...)

```
# .yardopts
_gem/README.md
```

<img width="191" height="194" alt="image" src="https://github.com/user-attachments/assets/125ad46f-74f7-49e0-923c-1c31d47114f7" />
